### PR TITLE
fix PrevBegin() and NextEnd() on edge case

### DIFF
--- a/plugin/vim-latex-objects.vim
+++ b/plugin/vim-latex-objects.vim
@@ -4,7 +4,7 @@ end
 
 function! <sid>NextEnd()
     let curline = line(".") + 1
-    let begins = 1
+    let begins = getline(".") !~ '.*\\end.*$'
     while begins > 0
         if getline(curline) =~ '.*\\begin.*$'
             let begins += 1
@@ -20,7 +20,7 @@ function! <sid>NextEnd()
 endfunction
 
 function! <sid>PrevBegin()
-    let curline = line(".")
+    let curline = line(".") - (getline(".") =~ '.*\\end.*$')
     let ends = 1
     while ends > 0
         if getline(curline) =~ '.*\\begin.*$'


### PR DESCRIPTION
Hi!

I love making some LaTeX configs, so I don't need to use vimtex and my config remains clear.
Your plugin is very useful to me and it's clean and small. :heart: 

But when the cursor is already on a ``'.*\\end.*$'`` line, `ie` and `ae` get the 'outer' environment. I would prefer them to take the environment of the current ``\\end``.

I've also noticed a similar behaviour with `im` and `am` when the cursor is on `$`, `\[` or `\]`.
And I'm also working on mappings like [surround.vim](http://github.com/tpope/vim-surround). The help tells us how to get `ys.c` and `ys.e` to surround with a command or an environment. But it doesn't allow `csc`, `dsc`, `cse` nor `dse` which would be usefull.

Let me know